### PR TITLE
Update standalone taxonomy and fix some lca code internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,10 @@ flowchart TB
          - [BLAST settings](#blast-settings-1)
          - [Classification using insect](#classification-using-insect)
          - [LCA collapse](#lca-collapse)
+            * [LCA options](#lca-options)
+            * [Standalone LCA](#standalone-lca)
             * [LCA worked example](#lca-worked-example)
             * [Using LCA with custom taxonomy and/or BLAST databases](#using-lca-with-custom-taxonomy-andor-blast-databases)
-            * [LCA options](#lca-options)
       + [Denoising/dereplication and zOTU inference](#denoisingdereplication-and-zotu-inference)
       + [zOTU curation using LULU](#zotu-curation-using-lulu)
       + [Resource allocation](#resource-allocation)
@@ -754,6 +755,30 @@ Options for the lowest common ancestor (LCA) method of taxonomy refinement.
 
 The LCA method will selectively collapse BLAST assignments to their lowest common ancestor based on user-defined variability and certainty thresholds. This script first filters BLAST results according to minimum quality thresholds (percent identity: `--lca-pid` and query coverage: `--lca-qcov`). For cases where zOTU sequences return multiple matches to the same sequence ID, the matches are summarized by the best combination of match scores. Then, results whose percent identity differs from the best result by more than a user-defined amount (`--lca-diff`) are discarded. Finally, zOTUs with taxonomic assignments that are consistent across remaining BLAST results will receive species-level taxonomy. Otherwise, the taxonomy of that zOTU will be collapsed to the lowest common ancestor of remaining BLAST results (if using NCBI taxonomy, the NCBI taxid for the common ancestor will also be retrieved). Two files are produced: a collapsed taxonomy table and an intermediate table retaining all zOTUs passing minimum quality thresholds. The intermediate table may be useful in determining why a given zOTU may have had its taxonomy collapsed.
 
+##### LCA options
+
+The following command-line options are available for the LCA collapse method:
+
+<small>**`--collapse-taxonomy`**</small>: Collapse assigned BLAST results by lowest common ancestor (LCA)  
+<small>**`--standalone-taxonomy`**</small>: Run LCA script standalone (i.e., separate from the pipeline) against user-supplied data  
+<small>**`--blast-file [file]`**</small>: (Only with --standalone-taxonomy) BLAST result table (e.g., output from the blast process)  
+<small>**`--zotu-table [file]`**</small>: (Only with --standalone-taxonomy) zOTU table file (e.g., output from the denoising process)  
+<small>**`--lca-lineage [file]`**</small>: Tabular file (TSV/CSV) matching taxnomic IDs (taxids) to taxonomic lineage (for use with custom BLAST db)  
+<small>**`--taxdump [file]`**</small>: Previously-downloaded NCBI taxonomy dump zip archive ([new_taxdump.zip](https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/taxdump_readme.txt))  
+<small>**`--dropped [str]`**</small>: Placeholder string for dropped taxonomic levels (default: 'dropped'). Pass "NA" for blank/NA  
+<small>**`--lca-qcov [num]`**</small>:  Minimum query coverage for LCA taxonomy refinement (default: 100)  
+<small>**`--lca-pid [num]`**</small>:  Minimum percent identity for LCA taxonomy refinement (default: 97)  
+<small>**`--lca-diff [num]`**</small>:  Maximum difference between percent identities (with identical query coverage) where shared taxonomy is retained (default: 1)  
+<small>**`--lca-taxon-filter [regex]`**</small>:  A regular expression with which to remove unwanted taxa from BLAST results. Defaults to filtering uncultured/environmental/synthetic sequences ('uncultured|environmental sample|clone|synthetic').  
+<small>**`--lca-case-insensitive`**</small>: Ignore case when applying the regex in `--lca-taxon-filter` (default: false).  
+<small>**`--lca-filter-max-qcov`**</small>: During LCA collapse, retain only BLAST records having the highest query coverage (default: false).  
+
+##### Standalone LCA
+rainbow_bridge can run the LCA collapse process independent of the rest of the pipeline. This is useful for experimenting with different values of percent ID and difference threshold, among other things. To run LCA in standalone mode, the pipeline must be run with the `--standalone-taxonomy` option. In addition to `--standalone-taxonomy`, you must supply a BLAST results file with the `--blast-file` option. You may also optionally provide a zOTU table using the `--zotu-table` option. When running LCA in standalone mode, the output files will be placed in the following directories:
+
+LCA taxonomy file: `output/standalone_taxonomy/lca/<settings>`  
+Merged zOTU table (if `--zotu-table` was present): `output/standalone_taxonomy/final`
+
 ##### LCA worked example
 
 Here is a brief worked example using default parameters (`--lca-pid 97`, `--lca-qcov 100`, `--lca-diff 1`) and BLAST results for two different zOTUs. In this example, one zOTU will be collapsed to LCA and the other will receive a species-level assignment. 
@@ -825,26 +850,6 @@ By default, rainbow_bridge assumes that taxonomy IDs (taxids) returned from BLAS
 
 
 To use a custom taxonomic lineage, pass this tabular lineage file to rainbow_bridge using the `--lca-lineage` option.
-
-##### LCA options
-
-The following command-line options are available for the LCA collapse method:
-
-<small>**`--collapse-taxonomy`**</small>: Collapse assigned BLAST results by lowest common ancestor (LCA)  
-<small>**`--standalone-taxonomy`**</small>: Run LCA script standalone (i.e., separate from the pipeline) against user-supplied data  
-<small>**`--blast-file [file]`**</small>: (Only with --standalone-taxonomy) BLAST result table (e.g., output from the blast process)  
-<small>**`--zotu-table [file]`**</small>: (Only with --standalone-taxonomy) zOTU table file (e.g., output from the denoising process)  
-<small>**`--lca-lineage [file]`**</small>: Tabular file (TSV/CSV) matching taxnomic IDs (taxids) to taxonomic lineage (for use with custom BLAST db)  
-<small>**`--taxdump [file]`**</small>: Previously-downloaded NCBI taxonomy dump zip archive ([new_taxdump.zip](https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/taxdump_readme.txt))  
-<small>**`--dropped [str]`**</small>: Placeholder string for dropped taxonomic levels (default: 'dropped'). Pass "NA" for blank/NA  
-<small>**`--lca-qcov [num]`**</small>:  Minimum query coverage for LCA taxonomy refinement (default: 100)  
-<small>**`--lca-pid [num]`**</small>:  Minimum percent identity for LCA taxonomy refinement (default: 97)  
-<small>**`--lca-diff [num]`**</small>:  Maximum difference between percent identities (with identical query coverage) where shared taxonomy is retained (default: 1)  
-<small>**`--lca-taxon-filter [regex]`**</small>:  A regular expression with which to remove unwanted taxa from BLAST results. Defaults to filtering uncultured/environmental/synthetic sequences ('uncultured|environmental sample|clone|synthetic').  
-<small>**`--lca-case-insensitive`**</small>: Ignore case when applying the regex in `--lca-taxon-filter` (default: false).  
-<small>**`--lca-filter-max-qcov`**</small>: During LCA collapse, retain only BLAST records having the highest query coverage (default: false).  
-
-
 
 ### Denoising/dereplication and zOTU inference
 These options control how (and by what tool) sequences are denoised and zOTUs are inferred By default, rainbow_bridge uses [vsearch](https://github.com/torognes/vsearch) (a free 64-bit clone of usearch), which does not suffer from the 4GB memory limit of the free version of [usearch](https://www.drive5.com/usearch/). You still retain the option of using either the free (32 bit) or commercial (64 bit) versions of usearch, if you really want to. 

--- a/bin/collapse_taxonomy.R
+++ b/bin/collapse_taxonomy.R
@@ -250,8 +250,7 @@ option_list <- list(
   make_option(c("-a", "--taxid-lineage"), action="store", default="", type="character", help="NCBI taxidlineage.dmp file"),
   make_option(c("-k", "--drop-blank"), action="store_true", default=TRUE, type="logical", help="Drop entries with completely blank taxonomic lineages"),
   make_option(c("-r", "--dropped"), action="store", default="dropped", type='character', help="Placeholder for dropped taxonomic ranks (default: %default)"),
-  make_option(c("-o", "--output"),action="store",default="lca_taxonomy.tsv",type="character",help="Output file (default: %default)"),
-  make_option(c("-z","--zotu-table"),action="store",default=NA,type="character",help="Optional (tab-separated) OTU table to merge with results (first column must be OTU ID)")
+  make_option(c("-o", "--output"),action="store",default="lca_taxonomy.tsv",type="character",help="Output file (default: %default)")
 )
 
 # use debug arguments if we have 'em
@@ -297,7 +296,6 @@ intermediate <- opt$options$intermediate
 semicolon <- opt$options$semicolon
 drop_blank <- opt$options$drop_blank
 dropped <- opt$options$dropped
-zotu_table_file <- opt$options$zotu_table
 
 if (str_to_lower(dropped) == "na") {
   dropped <- NA_character_
@@ -478,14 +476,6 @@ collapsed <- filtered %>%
   # if we have ranks not in the list, they'll end up at the end, but they'll still be there
   select(zotu,na.omit(match(hierarchy,colnames(.))),everything(),unique_hits,taxid,taxid_rank)
 
-
-# merge zotu table, if desired
-if (file_exists(zotu_table_file)) {
-  zotu_table <- read_tsv(zotu_table_file,col_types=cols())
-  # use inner join so we only get complete data
-  collapsed <- collapsed %>%
-    inner_join(zotu_table,by=setNames(colnames(zotu_table)[1],"zotu")) 
-}
 
 # save the collapsed output table
 write_tsv(collapsed,output_table,na="")

--- a/modules/modules.nf
+++ b/modules/modules.nf
@@ -2,7 +2,10 @@
 process lca {
   label 'r'
 
-  publishDir "${params.outDir}/taxonomy/lca/qcov${params.lcaQcov}_pid${params.lcaPid}_diff${params.lcaDiff}", mode: params.publishMode 
+  publishDir {
+    td = params.standaloneTaxonomy ? 'standalone_lca' : 'lca'
+    "${params.outDir}/taxonomy/${td}/qcov${params.lcaQcov}_pid${params.lcaPid}_diff${params.lcaDiff}"
+  }, mode: params.publishMode
 
   input:
     tuple path(blast_result), path(lineage), path('*')

--- a/modules/modules.nf
+++ b/modules/modules.nf
@@ -11,7 +11,8 @@ process lca {
     tuple path(blast_result), path(lineage), path('*')
 
   output:
-    tuple path("lca_intermediate*.tsv"), path("lca_taxonomy*.tsv"), emit: result
+    path("lca_taxonomy.tsv"), emit: taxonomy
+    path("lca_intermediate.tsv")
     path 'lca_settings.txt'
 
 

--- a/modules/modules.nf
+++ b/modules/modules.nf
@@ -3,8 +3,8 @@ process lca {
   label 'r'
 
   publishDir {
-    td = params.standaloneTaxonomy ? 'standalone_lca' : 'lca'
-    "${params.outDir}/taxonomy/${td}/qcov${params.lcaQcov}_pid${params.lcaPid}_diff${params.lcaDiff}"
+    td = params.standaloneTaxonomy ? 'standalone_taxonomy' : 'taxonomy'
+    "${params.outDir}/${td}/lca/qcov${params.lcaQcov}_pid${params.lcaPid}_diff${params.lcaDiff}"
   }, mode: params.publishMode
 
   input:

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -839,12 +839,10 @@ workflow {
     blast_result |
       combine(lineage) | 
       combine(ncbi_dumps) |
-      collapse_taxonomy | 
-      set { taxonomized }
+      collapse_taxonomy 
 
     // pull out lca table
-    taxonomized.result | 
-      map { it[1] } | 
+    collapse_taxonomy.out.taxonomy | 
       set { lca_taxonomy }
     
     // do this part if the zotu table exists
@@ -1500,14 +1498,12 @@ workflow {
       blast_result |
         combine(lineage) | 
         combine(ncbi_dumps) |
-        collapse_taxonomy |
-        set { taxonomized }
+        collapse_taxonomy
     }
 
     // prepare for final output
     if (lca && params.blast) {
-      taxonomized.result | 
-        map { it[1] } | 
+      collapse_taxonomy.out.taxonomy | 
         set { lca_taxonomy }
     } else {
       Channel.fromPath("NOTADANGFILE.nothing.lca",checkIfExists: false) | 
@@ -1545,8 +1541,7 @@ workflow {
       switch (params.taxonomy) {
         case "lca":
           if (lca) {
-            taxonomized.result | 
-              map { it[1] } |
+            collapse_taxonomy.out.taxonomy | 
               combine(zotu_table) | 
               combine( dereplicated | map { sid, uniques, zotus, zotutable -> zotus } ) |
               combine( Channel.fromPath(params.metadata, checkIfExists: true) ) | 

--- a/rainbow_bridge.nf
+++ b/rainbow_bridge.nf
@@ -725,8 +725,8 @@ process finalize {
   label 'r'
   
   publishDir {
-    td = params.standaloneTaxonomy ? '/standalone' : ''
-    "${params.outDir}/final${td}"
+    td = params.standaloneTaxonomy ? 'standalone_taxonomy/final' : 'final'
+    "${params.outDir}/${td}"
   }, mode: params.publishMode
 
   input:


### PR DESCRIPTION
This update subtly modifies the way that `--standalone-taxonomy` works. It now no longer requires a zotu table, though it will accept one if you provide it.

The taxonomy table (sans zotu abundances) will  now end up in `output/standalone_taxonomy/lca/<settings>`
If you provide a zotu table, it will be merged with the LCA output and put in `output/standalone_taxonomy/final`

resolves #113 
resolves #109 