### PR TITLE
Automatically change I's to N's in barcode files

### DIFF
--- a/bin/fix_barcode.awk
+++ b/bin/fix_barcode.awk
@@ -1,0 +1,4 @@
+#!/usr/bin/awk -f
+BEGIN { FS="\t"; OFS="\t" }
+/^#/ {print} 
+!/^#/ {gsub(/[Ii]/,"N",$4);gsub(/[Ii]/,"N",$5);print}


### PR DESCRIPTION
`obitools` doesn't support the `I` base ambiguity, so we change these to `N`'s as we encounter them, since it means the same thing.