### PR TITLE
Fix the way CPUs are allocated to processes

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -30,29 +30,32 @@ process {
   }
 
   // these labels control how many cpus get used based on certain conditions
+ 
+  // give 4 cpus to AdapterRemoval
 	withLabel: 'demux_cpus' {
-    cpus = { (demux || split) ? check_max( 1 * task.attempt, 'cpus' ) : cores }
+    cpus = cores >= 4 ? 4 : 1
   }
+
+  // allow all cpus
 	withLabel: 'all_cpus' { cpus = { cores } }
 
+  // allocate blast cpus
   withLabel: 'blast' {
     cpus = { params.insect ? cores / 2 : cores }
     memory = { params.insect ? mem / 2 : mem }
     container = 'ncbi/blast:latest'
   }
+
+  // alloacte insect cpus
   withLabel: 'insect' {
     cpus = { params.blast ? cores / 2 : cores }
     memory = { params.blast ? mem / 2 : mem }
     container = 'fishbotherer/r-tools:latest'
   }
 
-  /* limit total parallel processes to params.maxCpus */
-  /* TODO: make this configurable / variable by profile */
-  maxForks = cores
-
   cache = 'lenient' 
 
+  // set default cpus and memory
   cpus = { check_max( 1 * task.attempt, 'cpus' ) }
   memory = { check_max( 6.GB * task.attempt, 'memory' ) }
-  /* time = { check_max( 4.h * task.attempt, 'time' ) } */
 }

--- a/conf/base.config
+++ b/conf/base.config
@@ -29,27 +29,69 @@ process {
     }
   }
 
-  // these labels control how many cpus get used based on certain conditions
- 
-  // give 4 cpus to AdapterRemoval
-	withLabel: 'demux_cpus' {
-    cpus = cores >= 4 ? 4 : 1
+  // these labels control various aspects of resource allocation
+  withLabel:process_single {
+    cpus   = { 1           }
+    memory = { 6.GB * task.attempt }
+    // time   = { 4.h  * task.attempt }
   }
+  withLabel:process_low {
+    cpus   = { 2   * task.attempt }
+    memory = { 12.GB * task.attempt }
+    // time   = { 4.h   * task.attempt }
+  }
+  withLabel:process_lowish {
+    cpus   = { 4   * task.attempt }
+    memory = { 12.GB * task.attempt }
+    // time   = { 4.h   * task.attempt }
+  }
+  withLabel:process_medium {
+    cpus   = { 6   * task.attempt }
+    memory = { 36.GB * task.attempt }
+    // time   = { 8.h   * task.attempt }
+  }
+  withLabel:process_high {
+    cpus   = { 12  * task.attempt }
+    memory = { 72.GB * task.attempt }
+    // time   = { 16.h  * task.attempt }
+  }
+  withLabel:process_more_memory {
+    memory = { 10.GB * task.attempt }
+  }
+  withLabel:process_high_memory {
+    memory = { 200.GB * task.attempt }
+  }
+  withLabel:error_ignore {
+    errorStrategy = 'ignore'
+  }
+  withLabel:error_retry {
+    errorStrategy = 'retry'
+    maxRetries  = 2
+  } 
+ 
+//  // allocate cpus to AdapterRemoval
+// 	withLabel: 'demux_cpus' {
+//     if (get_p(params,'demultiplexedBy') == 'barcode' ) {
+//       cpus = cores > 1 ? cores-1 : cores
+//     } else {
+//       cpus = 4 * task.attempt
+//     }
+//   }
 
   // allow all cpus
 	withLabel: 'all_cpus' { cpus = { cores } }
 
   // allocate blast cpus
   withLabel: 'blast' {
-    cpus = { params.insect ? cores / 2 : cores }
-    memory = { params.insect ? mem / 2 : mem }
+    // cpus = { params.insect ? cores / 2 : cores }
+    // memory = { params.insect ? mem / 2 : mem }
     container = 'ncbi/blast:latest'
   }
 
   // alloacte insect cpus
   withLabel: 'insect' {
-    cpus = { params.blast ? cores / 2 : cores }
-    memory = { params.blast ? mem / 2 : mem }
+    // cpus = { params.blast ? cores / 2 : cores }
+    // memory = { params.blast ? mem / 2 : mem }
     container = 'fishbotherer/r-tools:latest'
   }
 

--- a/modules/modules.nf
+++ b/modules/modules.nf
@@ -1,6 +1,7 @@
 // run fastqc process
 process fastqc {
   label 'fastqc'
+  label 'process_single'
 
   publishDir "${params.outDir}/fastqc/${step}", mode: params.publishMode
 
@@ -28,6 +29,7 @@ process fastqc {
 // we do this for the non-demultiplexed samples
 process multiqc {
   label 'multiqc'
+  label 'process_single'
 
   publishDir "${params.outDir}/fastqc/${step}", mode: params.publishMode
 
@@ -44,6 +46,8 @@ process multiqc {
 
 // get a file from a URL
 process get_web {
+  label 'process_single'
+
   input:
     tuple val(location), path(localfile)
   output:
@@ -58,6 +62,7 @@ process get_web {
 // extract arbitrary files from a zip archive
 process extract_zip {
   label 'shell'
+  label 'process_single'
 
   input:
     tuple path(zipfile), val(f)
@@ -73,6 +78,7 @@ process extract_zip {
 // extract files from a .tar.gz archive
 process extract_targz {
   label 'shell'
+  label 'process_single'
 
   input:
     tuple path(archive), val(to_extract)

--- a/nextflow.config
+++ b/nextflow.config
@@ -225,6 +225,12 @@ profiles {
   
   /* standard profile is loaded by default */
   standard {
+
+    // make default executor local
+    // and limit max cpus to param value
+    executor.name = 'local'
+    executor.cpus = (int)get_p(params,'maxCpus')
+
     singularity {
       /* enable singularity and have it do automounts */
       enabled = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -230,6 +230,7 @@ profiles {
     // and limit max cpus to param value
     executor.name = 'local'
     executor.cpus = (int)get_p(params,'maxCpus')
+    executor.memory = get_p(params,'maxMemory')
 
     singularity {
       /* enable singularity and have it do automounts */


### PR DESCRIPTION
FIx process CPU allocation by explicitly allowing certain numbers of CPUs per process.
Also assign max cpus to executor, rather than process.maxForks.

fixes #132 